### PR TITLE
Fix broken OG and Twitter card meta tags (closes #6)

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,16 +8,26 @@
       name="description"
       content="oota-sushikuitee.net means Oota wants to eat sushi"
     />
-    <meta name="keywords" content="oota-sushikuitee" />
     <meta name="author" content="oota-sushikuitee" />
-    <meta property="og:title" content="oota-sushikuitee" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://oota-sushikuitee.net/404.html" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="oota-sushikuitee.net" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:title" content="oota-sushikuitee - 404 Not Found" />
     <meta
       property="og:description"
-      content="oota-sushikuitee.net means Oota wants to eat sushi"
+      content="The page you are looking for does not exist."
     />
-    <meta property="og:image" content="./img/mayo_no.png" />
-    <meta property="og:url" content="https://oota-sushikuitee.net" />
-    <meta name="twitter:card" content="./img/mayo_no.png" />
+    <meta property="og:image" content="https://oota-sushikuitee.net/img/mayo_no.png" />
+    <meta property="og:url" content="https://oota-sushikuitee.net/404.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="oota-sushikuitee - 404 Not Found" />
+    <meta
+      name="twitter:description"
+      content="The page you are looking for does not exist."
+    />
+    <meta name="twitter:image" content="https://oota-sushikuitee.net/img/mayo_no.png" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -8,16 +8,25 @@
       name="description"
       content="oota-sushikuitee.net means Oota wants to eat sushi"
     />
-    <meta name="keywords" content="oota-sushikuitee" />
     <meta name="author" content="oota-sushikuitee" />
+    <link rel="canonical" href="https://oota-sushikuitee.net/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="oota-sushikuitee.net" />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:title" content="oota-sushikuitee" />
     <meta
       property="og:description"
       content="oota-sushikuitee.net means Oota wants to eat sushi"
     />
-    <meta property="og:image" content="./img/mayo.png" />
-    <meta property="og:url" content="https://oota-sushikuitee.net" />
-    <meta name="twitter:card" content="./img/mayo.png" />
+    <meta property="og:image" content="https://oota-sushikuitee.net/img/mayo.png" />
+    <meta property="og:url" content="https://oota-sushikuitee.net/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="oota-sushikuitee" />
+    <meta
+      name="twitter:description"
+      content="oota-sushikuitee.net means Oota wants to eat sushi"
+    />
+    <meta name="twitter:image" content="https://oota-sushikuitee.net/img/mayo.png" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>


### PR DESCRIPTION
## What

- Replace `twitter:card` image path with the valid card type `summary_large_image`.
- Add `twitter:title`, `twitter:description`, and `twitter:image` so X/Twitter actually renders a card.
- Rewrite `og:image` and `og:url` to absolute `https://oota-sushikuitee.net/...` URLs.
- Add `og:type`, `og:site_name`, `og:locale`, and `<link rel="canonical">`.
- Add `<meta name="robots" content="noindex">` on `404.html` so it does not get indexed.
- Drop the legacy `<meta name="keywords">` tag (ignored by all major search engines).

## Why

The previous tags were silently broken: `twitter:card` expected an enum (`summary`, `summary_large_image`, `app`, `player`) but received a relative image path, so no Twitter card rendered at all. `og:image` used a relative URL which most OGP consumers (Facebook, Slack, Discord) can't resolve. Canonical and `og:type` were missing entirely. Net effect: shared links rendered as plain text instead of a preview, and the 404 page could end up indexed.

Closes #6