### PR TITLE
Add robots.txt and sitemap.xml (refs #8)

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /404.html
+
+Sitemap: https://oota-sushikuitee.net/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://oota-sushikuitee.net/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## What

- Add `/robots.txt` allowing all crawlers, disallowing `/404.html`, and pointing at the sitemap.
- Add `/sitemap.xml` with the apex URL.

## Why

Standard SEO discoverability files. `robots.txt` and `sitemap.xml` are the two files Google Search Console first looks for; without them the crawler has to fall back to link discovery only.

Favicon `<link>` wiring will be handled in a follow-up PR stacked on top of #7 to avoid a `<head>` conflict.

Refs #8