### PR TITLE
Add CSP, security headers, and Referrer-Policy to static pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'none'; style-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests"
+    />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>oota-sushikuitee.net - 404 Not Found</title>
     <meta
       name="description"

--- a/_headers
+++ b/_headers
@@ -1,0 +1,7 @@
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'none'; style-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: interest-cohort=(), browsing-topics=(), camera=(), microphone=(), geolocation=(), payment=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains

--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'none'; style-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests"
+    />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>oota-sushikuitee.net</title>
     <meta
       name="description"


### PR DESCRIPTION
## What

| File | Lines | Content |
|---|---|---|
| `_headers` | 8 (new) | Cloudflare Pages header rules: `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security` |

`index.html` and `404.html` (+5 lines each): at the top of `<head>`, add `<meta http-equiv="Content-Security-Policy" content="...">` and `<meta name="referrer" content="strict-origin-when-cross-origin">`.

Shared CSP value:

```
default-src 'self';
script-src 'none';
style-src 'self';
img-src 'self' data:;
font-src 'self';
base-uri 'self';
form-action 'none';
frame-ancestors 'none';
upgrade-insecure-requests
```

`_headers` additionally carries `nosniff` / `DENY` / `Permissions-Policy: interest-cohort=(), browsing-topics=(), camera=(), microphone=(), geolocation=(), payment=()` / `HSTS max-age=31536000; includeSubDomains` — headers that cannot be set via `<meta>` because they are HTTP-header-only.

## Why

The site is one static HTML page plus a 404 page. Zero scripts, no external CDN, no forms. The CSP can therefore tighten all the way to `script-src 'none'` and `form-action 'none'` without false positives. `frame-ancestors 'none'` blocks clickjacking, `Referrer-Policy` stops outbound referer leakage, and `Permissions-Policy` opts out of FLoC / Topics. `HSTS` is safe because Cloudflare Pages is always HTTPS. `preload` is omitted because it requires manual registration at hstspreload.org.

The meta tags duplicate what `_headers` already carries so the policy survives a future migration off Cloudflare Pages (to GitHub Pages or another host) — CSP and Referrer-Policy are the two headers that browsers also accept via `<meta>`. The rest (`nosniff` / `DENY` / `Permissions-Policy` / `HSTS`) are HTTP-only and stay in `_headers`.

This covers the applicable items from `docs/web-2026/07-security.md`'s "must" list (CSP, Permissions-Policy, integrity, SameSite, HSTS) for a static-only site.

## Note

The CF Pages delivery cannot be confirmed via GitHub APIs (`gh api repos/.../pages` returns 404 because GitHub Pages is not configured). Post-deploy verification:

```bash
curl -sI https://oota-sushikuitee.net/ | grep -iE 'csp|content-security|x-frame|referrer|permissions|strict-transport'
```

Local meta-tag check confirmed before push (`cat index.html | grep -i csp`).

## Related

resolve: #10
