### PR TITLE
Improve on-page SEO with structured data, H1, and sitemap cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,10 +15,11 @@
     />
     <meta name="author" content="oota-sushikuitee" />
     <link rel="canonical" href="https://oota-sushikuitee.net/" />
+    <link rel="icon" type="image/png" href="/img/mayo.png" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="oota-sushikuitee.net" />
     <meta property="og:locale" content="en_US" />
-    <meta property="og:title" content="oota-sushikuitee" />
+    <meta property="og:title" content="oota-sushikuitee.net" />
     <meta
       property="og:description"
       content="oota-sushikuitee.net means Oota wants to eat sushi"
@@ -26,13 +27,21 @@
     <meta property="og:image" content="https://oota-sushikuitee.net/img/mayo.png" />
     <meta property="og:url" content="https://oota-sushikuitee.net/" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="oota-sushikuitee" />
+    <meta name="twitter:title" content="oota-sushikuitee.net" />
     <meta
       name="twitter:description"
       content="oota-sushikuitee.net means Oota wants to eat sushi"
     />
     <meta name="twitter:image" content="https://oota-sushikuitee.net/img/mayo.png" />
     <link rel="stylesheet" href="style.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "oota-sushikuitee.net",
+        "url": "https://oota-sushikuitee.net/"
+      }
+    </script>
   </head>
   <body>
     <div class="header">
@@ -42,7 +51,7 @@
     </div>
     <div class="container">
       <img src="./img/mayo.png" alt="mayo-kun" class="center-image" />
-      <p>Sushi kuitee</p>
+      <h1 class="tagline">Sushi kuitee</h1>
     </div>
     <footer class="footer">
       <p>&copy; oota-sushikuitee.net 2024</p>

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
 Allow: /
-Disallow: /404.html
 
 Sitemap: https://oota-sushikuitee.net/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://oota-sushikuitee.net/</loc>
-    <changefreq>monthly</changefreq>
-    <priority>1.0</priority>
+    <lastmod>2026-06-12</lastmod>
   </url>
 </urlset>

--- a/style.css
+++ b/style.css
@@ -60,6 +60,13 @@ p {
   color: #666;
 }
 
+.tagline {
+  margin: 20px 0 0;
+  color: #666;
+  font-size: 1em;
+  font-weight: normal;
+}
+
 .footer {
   width: 100%;
   text-align: center;


### PR DESCRIPTION
## What

- Add `WebSite` JSON-LD structured data to the home page
- Promote the "Sushi kuitee" tagline from `<p>` to `<h1>` (page previously had no H1); visual appearance is preserved via a `.tagline` style
- Add a favicon using the existing `img/mayo.png`
- Align `og:title` / `twitter:title` with the site name
- Add `lastmod` to `sitemap.xml` and remove `changefreq` / `priority` (ignored by Google)
- Remove `Disallow: /404.html` from `robots.txt` — the page returns HTTP 404 and cannot be indexed anyway

## Why

2026 SEO guidelines review: the page is indexed and receiving impressions, but lacked basic on-page signals (H1, structured data) and carried sitemap/robots noise.

Closes #12