### PR TITLE
Fix 404 page rendering on nested paths and clean up page metadata

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,10 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'none'; style-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests"
-    />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>oota-sushikuitee.net - 404 Not Found</title>
     <meta
@@ -15,7 +11,7 @@
     />
     <meta name="author" content="oota-sushikuitee" />
     <meta name="robots" content="noindex" />
-    <link rel="canonical" href="https://oota-sushikuitee.net/404.html" />
+    <link rel="icon" type="image/png" href="/img/mayo.png" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="oota-sushikuitee.net" />
     <meta property="og:locale" content="en_US" />
@@ -25,29 +21,35 @@
       content="The page you are looking for does not exist."
     />
     <meta property="og:image" content="https://oota-sushikuitee.net/img/mayo_no.png" />
-    <meta property="og:url" content="https://oota-sushikuitee.net/404.html" />
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="oota-sushikuitee - 404 Not Found" />
     <meta
       name="twitter:description"
       content="The page you are looking for does not exist."
     />
     <meta name="twitter:image" content="https://oota-sushikuitee.net/img/mayo_no.png" />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
-    <div class="header">
-      <a href="https://github.com/oota-sushikuitee" class="site-name"
+    <header class="header">
+      <a
+        href="https://github.com/oota-sushikuitee"
+        class="site-name"
+        aria-label="oota-sushikuitee on GitHub"
         >oota-sushikuitee.net</a
       >
-    </div>
+    </header>
     <div class="container">
-      <img src="./img/mayo_no.png" alt="mayo-kun" class="center-image" />
+      <img
+        src="/img/mayo_no.png"
+        alt="mayo-kun looking disappointed"
+        class="center-image"
+      />
       <h1>404 - Not Found</h1>
       <p>Sorry, the page you are looking for does not exist.</p>
     </div>
     <footer class="footer">
-      <p>&copy; oota-sushikuitee.net 2024</p>
+      <p>&copy; oota-sushikuitee.net</p>
     </footer>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'none'; style-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests"
-    />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>oota-sushikuitee.net</title>
     <meta
@@ -26,14 +22,14 @@
     />
     <meta property="og:image" content="https://oota-sushikuitee.net/img/mayo.png" />
     <meta property="og:url" content="https://oota-sushikuitee.net/" />
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="oota-sushikuitee.net" />
     <meta
       name="twitter:description"
       content="oota-sushikuitee.net means Oota wants to eat sushi"
     />
     <meta name="twitter:image" content="https://oota-sushikuitee.net/img/mayo.png" />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="/style.css" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -44,17 +40,20 @@
     </script>
   </head>
   <body>
-    <div class="header">
-      <a href="https://github.com/oota-sushikuitee" class="site-name"
+    <header class="header">
+      <a
+        href="https://github.com/oota-sushikuitee"
+        class="site-name"
+        aria-label="oota-sushikuitee on GitHub"
         >oota-sushikuitee.net</a
       >
-    </div>
+    </header>
     <div class="container">
-      <img src="./img/mayo.png" alt="mayo-kun" class="center-image" />
+      <img src="/img/mayo.png" alt="mayo-kun" class="center-image" />
       <h1 class="tagline">Sushi kuitee</h1>
     </div>
     <footer class="footer">
-      <p>&copy; oota-sushikuitee.net 2024</p>
+      <p>&copy; oota-sushikuitee.net</p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
## What
- `404.html` / `index.html`: switch stylesheet, image, and favicon references to root-absolute paths (`/style.css`, `/img/...`).
- `404.html`: add the missing favicon link, drop the `canonical` / `og:url` pointing at `/404.html`, and give the error image a distinct alt text.
- Both pages: remove the duplicated `<meta http-equiv="Content-Security-Policy">` (the `_headers` file is the single source of truth; `frame-ancestors` is ignored in meta CSP anyway), switch `twitter:card` to `summary` (the 200×200 images do not meet `summary_large_image` minimums), use a semantic `<header>`, add an aria-label to the GitHub link, and drop the hardcoded 2024 copyright year.

## Why
Cloudflare Pages serves `404.html` at the requested URL, so relative references like `style.css` resolve to `/nonexistent/deep/style.css` on nested 404s — verified live: the page renders unstyled with a broken image. The `canonical` on a `noindex` page and the meta/header CSP duplication are contradictions that would drift over time.

## Related
(no issue — public repo, direct PR per working convention)