### PR TITLE
Write real stale-bot messages and pin actions/stale to a commit SHA

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,9 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
-          stale-issue-message: "Message to comment on stale issues. If none provided, will not mark issues stale"
-          stale-pr-message: "Message to comment on stale PRs. If none provided, will not mark PRs stale"
+          stale-issue-message: "This issue has been inactive for 60 days and is marked as stale. It will be closed in 7 days if there is no further activity."
+          stale-pr-message: "This pull request has been inactive for 60 days and is marked as stale. It will be closed in 7 days if there is no further activity."
+          close-issue-message: "Closing this issue because it has been stale for 7 days with no activity."
+          close-pr-message: "Closing this pull request because it has been stale for 7 days with no activity."


### PR DESCRIPTION
## What
- Replace the placeholder `stale-issue-message` / `stale-pr-message` strings (copied verbatim from the action docs) with real messages, and add explicit `close-issue-message` / `close-pr-message`.
- Pin `actions/stale` to a full commit SHA (`v10.3.0`), upgrading from the floating `v9` tag.

## Why
The workflow currently comments the literal docs text "Message to comment on stale issues. If none provided, will not mark issues stale" on real issues and PRs before closing them. SHA pinning follows the org convention already applied in sibling repos.

## Related
(no issue — public repo, direct PR per working convention)